### PR TITLE
[YGSTR-33] Load sessions only for Drupal's locations

### DIFF
--- a/modules/openy_traction_rec_import/openy_traction_rec_import.services.yml
+++ b/modules/openy_traction_rec_import/openy_traction_rec_import.services.yml
@@ -25,6 +25,13 @@ services:
       - '@file_system'
       - '@event_dispatcher'
       - '@config.factory'
+      - '@openy_traction_rec_import.locations_mapping'
+
+  openy_traction_rec_import.locations_mapping:
+    class: Drupal\openy_traction_rec_import\LocationsMappingHelper
+    arguments:
+      - '@config.factory'
+      - '@entity_type.manager'
 
   openy_traction_rec_import.migrate_subscriber:
     class: '\Drupal\openy_traction_rec_import\EventSubscriber\MigrateEventSubscriber'

--- a/modules/openy_traction_rec_import/src/LocationsMappingHelper.php
+++ b/modules/openy_traction_rec_import/src/LocationsMappingHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\openy_traction_rec_import;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Contains related to mapping Traction Rec locations functionality.
+ */
+class LocationsMappingHelper {
+
+  /**
+   * The config factory.
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * The entity type manager service.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Constructors LocationsMappingHelper.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Build the location map.
+   *
+   * @return array
+   *   The mapping array.
+   */
+  public function getMapping(): array {
+    // We'll take each config entry: salesforce_id:drupal_id:comment and convert
+    // it to [salesforce_id => ['drupal_id' => id, 'comment' => comment]] so
+    // we can use the salesforce_id as the index.
+    $locations_map_config = $this->configFactory->get('openy_traction_rec_import.settings')->get('locations') ?? [];
+    $locations_map = [];
+    foreach ($locations_map_config as $row) {
+      $row = explode(':', $row, 3);
+      // If there are less than two items then this is not a valid mapping.
+      if (count($row) < 2) {
+        continue;
+      }
+      // Construct an array of the mapping config, indexed by Salesforce ID.
+      $locations_map[$row[0]] = [
+        'drupal_id' => $row[1],
+        'comment' => $row[2] ?? $row[0] . ' => ' . $row[1],
+      ];
+    }
+    return $locations_map;
+  }
+
+  /**
+   * Return mapped TractionRec locations id's.
+   *
+   * @return arraystring
+   *   The mapped TractionRec locations id's.
+   */
+  public function getMappedIds(): array {
+    $mapping = $this->getMapping();
+    return array_keys($mapping);
+  }
+
+  /**
+   * Return mapped Drupal location node.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   The mapped Drupal location node.
+   */
+  public function getMappedNode(string $location_id): NodeInterface|null {
+    $locations_map = $this->getMapping();
+    $nid = $locations_map[$location_id]['drupal_id'] ?? NULL;
+
+    if (!$nid) {
+      return NULL;
+    }
+
+    /** @var ?\Drupal\node\NodeInterface $node */
+    $node = $this->entityTypeManager->getStorage('node')->load($nid);
+
+    if (!$node) {
+      throw new \Exception("Location node not found: {$locations_map[$location_id]['comment']}");
+    }
+
+    return $node;
+  }
+
+}

--- a/modules/openy_traction_rec_import/src/Plugin/migrate/process/LocationByTitle.php
+++ b/modules/openy_traction_rec_import/src/Plugin/migrate/process/LocationByTitle.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\openy_traction_rec_import\Plugin\migrate\process;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
+use Drupal\openy_traction_rec_import\LocationsMappingHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,9 +28,9 @@ class LocationByTitle extends ProcessPluginBase implements ContainerFactoryPlugi
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
-   * The config factory.
+   * The locations mapping helper.
    */
-  protected ConfigFactoryInterface $configFactory;
+  protected LocationsMappingHelper $locationsMapping;
 
   /**
    * LocationByTitle constructor.
@@ -43,13 +43,13 @@ class LocationByTitle extends ProcessPluginBase implements ContainerFactoryPlugi
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The configuration factory.
+   * @param \Drupal\openy_traction_rec_import\LocationsMappingHelper $locations_mapping
+   *   The locations mapping helper.
    */
-  public function __construct(array $configuration, string $plugin_id, mixed $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
+  public function __construct(array $configuration, string $plugin_id, mixed $plugin_definition, EntityTypeManagerInterface $entity_type_manager, LocationsMappingHelper $locations_mapping) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
-    $this->configFactory = $config_factory;
+    $this->locationsMapping = $locations_mapping;
   }
 
   /**
@@ -61,7 +61,7 @@ class LocationByTitle extends ProcessPluginBase implements ContainerFactoryPlugi
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
-      $container->get('config.factory')
+      $container->get('openy_traction_rec_import.locations_mapping')
     );
   }
 
@@ -72,37 +72,14 @@ class LocationByTitle extends ProcessPluginBase implements ContainerFactoryPlugi
     $location_name = $value[0] ?? '';
     $location_id = $value[1] ?? '';
 
-    // Build the location map:
-    // We'll take each config entry: salesforce_id:drupal_id:comment and convert
-    // it to [salesforce_id => ['drupal_id' => id, 'comment' => comment]] so
-    // we can use the salesforce_id as the index.
-    $locations_map_config = $this->configFactory->get('openy_traction_rec_import.settings')->get('locations');
-    $locations_map = [];
-    foreach ($locations_map_config as $row) {
-      $row = explode(':', $row, 3);
-      // If there are less than two items then this is not a valid mapping.
-      if (count($row) < 2) {
-        continue;
-      }
-      // Construct an array of the mapping config, indexed by Salesforce ID.
-      $locations_map[$row[0]] = [
-        'drupal_id' => $row[1],
-        'comment' => $row[2] ?? $row[0] . ' => ' . $row[1],
-      ];
-    }
-
     try {
-      $node_storage = $this->entityTypeManager->getStorage('node');
-
       // First try to choose the location from the map...
-      if (!empty($locations_map) && isset($locations_map[$location_id])) {
-        $node = $node_storage->load($locations_map[$location_id]['drupal_id']);
-        if (!$node) {
-          throw new MigrateSkipRowException("Location node not found: {$locations_map[$location_id]['comment']}");
-        }
-      }
+      $node = $this->locationsMapping->getMappedNode($location_id);
+
       // If we can't find a location mapping, try matching by Title.
-      else {
+      if (!$node) {
+        $node_storage = $this->entityTypeManager->getStorage('node');
+
         $locations = $node_storage->getQuery()
           ->condition('title', $location_name)
           ->condition('type', ['branch', 'camp'], 'IN')

--- a/modules/openy_traction_rec_import/src/Plugin/migrate/process/LocationByTitle.php
+++ b/modules/openy_traction_rec_import/src/Plugin/migrate/process/LocationByTitle.php
@@ -103,11 +103,19 @@ class LocationByTitle extends ProcessPluginBase implements ContainerFactoryPlugi
       }
       // If we can't find a location mapping, try matching by Title.
       else {
-        $locations = $node_storage->loadByProperties(['title' => $location_name]);
-        if (!$locations) {
+        $locations = $node_storage->getQuery()
+          ->condition('title', $location_name)
+          ->condition('type', ['branch', 'camp'], 'IN')
+          ->range(0, 1)
+          ->accessCheck(FALSE)
+          ->execute();
+
+        if (empty($locations)) {
           throw new MigrateSkipRowException("Location node not found: $location_name");
         }
+
         // LoadByProperties can return more than one, so just take the first.
+        $locations = $node_storage->loadMultiple($locations);
         $node = reset($locations);
       }
 

--- a/modules/openy_traction_rec_import/src/TractionRecFetcher.php
+++ b/modules/openy_traction_rec_import/src/TractionRecFetcher.php
@@ -41,6 +41,11 @@ class TractionRecFetcher {
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * The locations mapping helper.
+   */
+  protected LocationsMappingHelper $locationsMapping;
+
+  /**
    * JSON Directory name.
    */
   protected string $directory;
@@ -56,17 +61,21 @@ class TractionRecFetcher {
    *   The event dispatcher.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\openy_traction_rec_import\LocationsMappingHelper $locations_mapping
+   *   The locations mapping helper.
    */
   public function __construct(
     TractionRecInterface $traction_rec,
     FileSystemInterface $file_system,
     EventDispatcherInterface $event_dispatcher,
-    ConfigFactoryInterface $config_factory
+    ConfigFactoryInterface $config_factory,
+    LocationsMappingHelper $locations_mapping
   ) {
     $this->tractionRec = $traction_rec;
     $this->fileSystem = $file_system;
     $this->eventDispatcher = $event_dispatcher;
     $this->configFactory = $config_factory;
+    $this->locationsMapping = $locations_mapping;
 
     $this->fileSystem->prepareDirectory($this->storagePath, FileSystemInterface::CREATE_DIRECTORY);
     $this->directory = $this->storagePath . date('YmdHi') . '/';
@@ -98,7 +107,7 @@ class TractionRecFetcher {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function fetchSessions(): array {
-    $result = $this->tractionRec->loadCourseOptions();
+    $result = $this->tractionRec->loadCourseOptions($this->locationsMapping->getMappedIds());
 
     if (empty($result['records'])) {
       return [];

--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -125,9 +125,9 @@ class TractionRec implements TractionRecInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadCourseOptions(): array {
+  public function loadCourseOptions(array $locations = []): array {
     try {
-      $result = $this->tractionRecClient->executeQuery('SELECT
+      $query = 'SELECT
         TREX1__Course_Option__r.id,
         TREX1__Course_Option__r.name,
         TREX1__Course_Option__r.TREX1__Available_Online__c,
@@ -169,8 +169,17 @@ class TractionRec implements TractionRecInterface {
         AND TREX1__Course_Option__r.TREX1__Register_Online_To_Date__c > YESTERDAY
         AND TREX1__Course_Option__r.TREX1__End_Date__c >= TODAY
         AND TREX1__Course_Option__r.TREX1__Start_Date__c != null
-        AND TREX1__Course_Session__r.TREX1__Num_Option_Entitlements__c <= 1');
+        AND TREX1__Course_Session__r.TREX1__Num_Option_Entitlements__c <= 1';
 
+      if (!empty($locations)) {
+        $locations = array_map(function ($location_id) {
+          $location_id = '\'' . $location_id . '\'';
+          return $location_id;
+        }, $locations);
+        $query .= ' AND TREX1__Course_Option__r.TREX1__Location__c IN (' . implode(',', $locations) . ')';
+      }
+
+      $result = $this->tractionRecClient->executeQuery($query);
       return $this->simplify($result);
     }
     catch (\Exception | GuzzleException $e) {

--- a/src/TractionRec.php
+++ b/src/TractionRec.php
@@ -168,7 +168,8 @@ class TractionRec implements TractionRecInterface {
         AND TREX1__Course_Option__r.TREX1__Day_of_Week__c  != null
         AND TREX1__Course_Option__r.TREX1__Register_Online_To_Date__c > YESTERDAY
         AND TREX1__Course_Option__r.TREX1__End_Date__c >= TODAY
-        AND TREX1__Course_Option__r.TREX1__Start_Date__c != null');
+        AND TREX1__Course_Option__r.TREX1__Start_Date__c != null
+        AND TREX1__Course_Session__r.TREX1__Num_Option_Entitlements__c <= 1');
 
       return $this->simplify($result);
     }

--- a/src/TractionRecInterface.php
+++ b/src/TractionRecInterface.php
@@ -36,10 +36,13 @@ interface TractionRecInterface {
   /**
    * Loads the list of TractionRec course options.
    *
+   * @param arraystring $locations
+   *   (Optional) Filters course options by TractionRec locations ID's.
+   *
    * @return array
    *   The list of options.
    */
-  public function loadCourseOptions(): array;
+  public function loadCourseOptions(array $locations = []): array;
 
   /**
    * Loads membership types.


### PR DESCRIPTION
- added condition related to this field TREX__Num_Option_Entitlements  
- now we use mapping of locations to fetch only sessions related to our mapping (locations that exist in drupal)
- in the code where we set location for sessions, added condition to load nodes of types branch and camp, to prevents situation when we set activity in location field