### PR TITLE
Make Traction Rec API request timeout configurable

### DIFF
--- a/config/install/openy_traction_rec.settings.yml
+++ b/config/install/openy_traction_rec.settings.yml
@@ -6,3 +6,4 @@ private_key: ''
 services_base_url: ''
 community_url: ''
 api_base_url: ''
+api_request_timeout: 90

--- a/openy_traction_rec.install
+++ b/openy_traction_rec.install
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Install and update hooks.
+ */
+
+/**
+ * Set a default value for the new API request timeout setting.
+ */
+function openy_traction_rec_update_9101(): void {
+  $config = \Drupal::configFactory()->getEditable('openy_traction_rec.settings');
+  if ($config->get('api_request_timeout') === NULL) {
+    $config->set('api_request_timeout', 90)->save();
+  }
+}

--- a/src/Form/TractionRecSettings.php
+++ b/src/Form/TractionRecSettings.php
@@ -6,6 +6,7 @@ namespace Drupal\openy_traction_rec\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\openy_traction_rec\TractionRecClient;
 
 /**
  * Settings form for Traction Rec integration.
@@ -88,6 +89,15 @@ class TractionRecSettings extends ConfigFormBase {
       '#required' => TRUE,
     ];
 
+    $form['api_request_timeout'] = [
+      '#type' => 'number',
+      '#title' => $this->t('API request timeout'),
+      '#default_value' => $config->get('api_request_timeout') ?: TractionRecClient::DEFAULT_REQUEST_TIMEOUT,
+      '#description' => $this->t('Timeout, in seconds, for requests to the Salesforce/Traction Rec API. Increase this if fetch operations are failing with cURL timeout errors.'),
+      '#min' => 1,
+      '#required' => TRUE,
+    ];
+
     $form['private_key'] = [
       '#type' => 'key_select',
       '#key_filters' => ['type' => 'openy_tr_private_key'],
@@ -114,6 +124,7 @@ class TractionRecSettings extends ConfigFormBase {
     $config->set('services_base_url', $form_state->getValue('services_base_url'));
     $config->set('community_url', $form_state->getValue('community_url'));
     $config->set('api_base_url', $form_state->getValue('api_base_url'));
+    $config->set('api_request_timeout', $form_state->getValue('api_request_timeout'));
     $config->save();
 
     parent::submitForm($form, $form_state);

--- a/src/TractionRecClient.php
+++ b/src/TractionRecClient.php
@@ -22,6 +22,11 @@ use GuzzleHttp\Exception\RequestException;
 class TractionRecClient implements TractionRecClientInterface {
 
   /**
+   * Default request timeout in seconds, used if no config value is set.
+   */
+  const DEFAULT_REQUEST_TIMEOUT = 90;
+
+  /**
    * The Traction Rec settings.
    */
   protected ImmutableConfig $tractionRecSettings;
@@ -105,6 +110,7 @@ class TractionRecClient implements TractionRecClientInterface {
     try {
       $response = $this->http->request('POST', $token_url, [
         'form_params' => $post_fields,
+        'timeout' => $this->getRequestTimeout(),
       ]);
     }
     catch (RequestException $e) {
@@ -175,6 +181,7 @@ class TractionRecClient implements TractionRecClientInterface {
         'headers' => [
           'Authorization' => 'Bearer ' . $access_token,
         ],
+        'timeout' => $this->getRequestTimeout(),
       ]);
 
     }
@@ -211,6 +218,7 @@ class TractionRecClient implements TractionRecClientInterface {
       $options['headers'] = [
         'Authorization' => 'Bearer ' . $access_token,
       ];
+      $options['timeout'] = $options['timeout'] ?? $this->getRequestTimeout();
       $response = $this->http->request($method, $url, $options);
     }
     catch (RequestException $e) {
@@ -224,6 +232,17 @@ class TractionRecClient implements TractionRecClientInterface {
     $query_request_body = $response->getBody()->getContents();
 
     return json_decode($query_request_body, TRUE);
+  }
+
+  /**
+   * Returns the configured request timeout, in seconds.
+   *
+   * @return float
+   *   The request timeout.
+   */
+  protected function getRequestTimeout(): float {
+    $timeout = $this->tractionRecSettings->get('api_request_timeout');
+    return is_numeric($timeout) && $timeout > 0 ? (float) $timeout : self::DEFAULT_REQUEST_TIMEOUT;
   }
 
 }


### PR DESCRIPTION
Salesforce query requests were using Drupal core's default 30s Guzzle timeout with no way to override it, causing frequent cURL error 28 timeouts on heavier queries (course options, course sessions, program categories). Adds an "API request timeout" field to the settings form, defaulting to 90 seconds, applied to all TractionRecClient requests.

## Steps to test
- [ ] Step 1
- [ ] Step 2

## Checklist
- [ ] Self-reviewed
- [ ] CI passing
